### PR TITLE
Make it work with the latest versions of eventemitter3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,25 +1,18 @@
+sudo: false
 language: node_js
 node_js:
   - "0.12"
-  - "0.11"
   - "0.10"
-  - "0.9"
   - "0.8"
-  - "iojs-v1.1"
-  - "iojs-v1.0"
+  - "iojs"
 before_install:
-  - "npm install -g npm@1.4.x"
+  - 'if [ "${TRAVIS_NODE_VERSION}" == "0.8" ]; then npm install -g npm@2.11.1; fi'
 script:
   - "npm run test-travis"
 after_script:
   - "npm install coveralls@2.11.x && cat coverage/lcov.info | coveralls"
 matrix:
   fast_finish: true
-  allow_failures:
-    - node_js: "0.11"
-    - node_js: "0.9"
-    - node_js: "iojs-v1.1"
-    - node_js: "iojs-v1.0"
 notifications:
   irc:
     channels:

--- a/index.js
+++ b/index.js
@@ -1,5 +1,7 @@
 'use strict';
 
+var has = Object.prototype.hasOwnProperty;
+
 /**
  * An auto incrementing id which we can use to create "unique" Ultron instances
  * so we can track the event emitters that are added through the Ultron
@@ -77,9 +79,7 @@ Ultron.prototype.remove = function remove() {
     args = [];
 
     for (event in this.ee._events) {
-      if (this.ee._events.hasOwnProperty(event)) {
-        args.push(event);
-      }
+      if (has.call(this.ee._events, event)) args.push(event);
     }
   }
 
@@ -89,6 +89,10 @@ Ultron.prototype.remove = function remove() {
     for (var j = 0; j < listeners.length; j++) {
       event = listeners[j];
 
+      //
+      // Once listeners have a `listener` property that stores the real listener
+      // in the EventEmitter that ships with Node.js.
+      //
       if (event.listener) {
         if (event.listener.__ultron !== this.id) continue;
         delete event.listener.__ultron;

--- a/package.json
+++ b/package.json
@@ -28,10 +28,10 @@
   "author": "Arnout Kazemier",
   "license": "MIT",
   "devDependencies": {
-    "assume": "1.1.x",
-    "eventemitter3": "0.1.x",
+    "assume": "1.2.x",
+    "eventemitter3": "1.1.x",
     "istanbul": "0.3.x",
-    "mocha": "2.1.x",
+    "mocha": "2.2.x",
     "pre-commit": "1.0.x"
   },
   "bugs": {


### PR DESCRIPTION
The `remove` method throws an error if `Ultron` is used with the latest versions of `EventEmitter3`.
This happens because the `_events` object does not have the [`hasOwnProperty`](https://github.com/unshiftio/ultron/blob/5cb5f8caf28446a4aded9e62bcd85952ddac1d81/index.js#L80) method.

This patch fixes the issue using `Object.keys()`.

If browser support is a concern, we can add a polyfill or use the original loop without the `hasOwnProperty` check. There shouldn't be a problem given that `_events` does not inherit from anything and `for..in` only returns enumerable properties.